### PR TITLE
Expose endpoint_auto_confirms property for subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This module sets up an SNS topic and adds up to 5 subscriptions.
 
 ```HCL
 module "sns" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//?ref=v0.12.0"
 
- name = "my-example-topic"
+  name = "my-example-topic"
 
 }
 ```
@@ -41,6 +41,9 @@ The following module variables were updated to better meet current Rackspace sty
 
 - `topic_name` -> `name`
 
+### Limitations  
+This module does not support `email` or `email-json` as a protocol as  Terraform does not currently support them. See: https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html for more details.
+
 ## Providers
 
 | Name | Version |
@@ -61,6 +64,11 @@ The following module variables were updated to better meet current Rackspace sty
 | endpoint\_3 | The subscription's endpoint #3. | `string` | `""` | no |
 | endpoint\_4 | The subscription's endpoint #4. | `string` | `""` | no |
 | endpoint\_5 | The subscription's endpoint #5. | `string` | `""` | no |
+| endpoint\_auto\_confirms\_1 | Boolean indicating whether endpoint #1 is capable of auto confirming subscription (required for HTTP protocols). | `bool` | `false` | no |
+| endpoint\_auto\_confirms\_2 | Boolean indicating whether endpoint #2 is capable of auto confirming subscription (required for HTTP protocols). | `bool` | `false` | no |
+| endpoint\_auto\_confirms\_3 | Boolean indicating whether endpoint #3 is capable of auto confirming subscription (required for HTTP protocols). | `bool` | `false` | no |
+| endpoint\_auto\_confirms\_4 | Boolean indicating whether endpoint #4 is capable of auto confirming subscription (required for HTTP protocols). | `bool` | `false` | no |
+| endpoint\_auto\_confirms\_5 | Boolean indicating whether endpoint #5 is capable of auto confirming subscription (required for HTTP protocols). | `bool` | `false` | no |
 | name | A name for the topic | `string` | n/a | yes |
 | protocol\_1 | The protocol you want to use in your endpoint #1. Supported protocols include: http, https, sms, sqs, application, lambda. | `string` | `""` | no |
 | protocol\_2 | The protocol you want to use in your endpoint #2. Supported protocols include: http, https, sms, sqs, application, lambda. | `string` | `""` | no |

--- a/examples/sns_sqs.tf
+++ b/examples/sns_sqs.tf
@@ -17,7 +17,7 @@ resource "aws_sqs_queue" "my_sqs" {
 }
 
 module "sns_sqs" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//?ref=v0.12.1"
 
   name = "${random_string.sqs_rstring.result}-my-example-topic"
 

--- a/main.tf
+++ b/main.tf
@@ -1,46 +1,49 @@
 /**
- *# aws-terraform-sns
+ * # aws-terraform-sns
  *
- *This module sets up an SNS topic and adds up to 5 subscriptions.
+ * This module sets up an SNS topic and adds up to 5 subscriptions.
  *
- *## Basic Usage
+ * ## Basic Usage
  *
- *```HCL
- *module "sns" {
- *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//?ref=v0.12.0"
+ * ```HCL
+ * module "sns" {
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//?ref=v0.12.0"
  *
- *  name = "my-example-topic"
+ *   name = "my-example-topic"
  *
- *}
- *```
+ * }
+ * ```
  *
- *Full working references are available at [examples](examples)
+ * Full working references are available at [examples](examples)
  *
- *## Terraform 0.12 upgrade
+ * ## Terraform 0.12 upgrade
  *
- *Several changes were required while adding terraform 0.12 compatibility.  The following changes should be
- *made when upgrading from a previous release to version 0.12.0 or higher.
+ * Several changes were required while adding terraform 0.12 compatibility.  The following changes should be
+ * made when upgrading from a previous release to version 0.12.0 or higher.
  *
- *### Terraform State File
+ * ### Terraform State File
  *
- *Several resources were updated with new logical names, better meet current Rackspace style guides.
- *The following statements can be used to update existing resources.  In each command, `<MODULE_NAME>`
- *should be replaced with the logic name used where the module is referenced.
+ * Several resources were updated with new logical names, better meet current Rackspace style guides.
+ * The following statements can be used to update existing resources.  In each command, `<MODULE_NAME>`
+ * should be replaced with the logic name used where the module is referenced.
  *
- *```
- *terraform state mv module.<MODULE_NAME>.aws_sns_topic.MySNSTopic module.<MODULE_NAME>.aws_sns_topic.topic
- *terraform state mv module.<MODULE_NAME>.aws_sns_topic_subscription.Subscription1 module.<MODULE_NAME>.aws_sns_topic_subscription.subscription1
- *terraform state mv module.<MODULE_NAME>.aws_sns_topic_subscription.Subscription2 module.<MODULE_NAME>.aws_sns_topic_subscription.subscription2
- *terraform state mv module.<MODULE_NAME>.aws_sns_topic_subscription.Subscription3 module.<MODULE_NAME>.aws_sns_topic_subscription.subscription3
- *terraform state mv module.<MODULE_NAME>.aws_sns_topic_subscription.Subscription4 module.<MODULE_NAME>.aws_sns_topic_subscription.subscription4
- *terraform state mv module.<MODULE_NAME>.aws_sns_topic_subscription.Subscription5 module.<MODULE_NAME>.aws_sns_topic_subscription.subscription5
- *```
+ * ```
+ * terraform state mv module.<MODULE_NAME>.aws_sns_topic.MySNSTopic module.<MODULE_NAME>.aws_sns_topic.topic
+ * terraform state mv module.<MODULE_NAME>.aws_sns_topic_subscription.Subscription1 module.<MODULE_NAME>.aws_sns_topic_subscription.subscription1
+ * terraform state mv module.<MODULE_NAME>.aws_sns_topic_subscription.Subscription2 module.<MODULE_NAME>.aws_sns_topic_subscription.subscription2
+ * terraform state mv module.<MODULE_NAME>.aws_sns_topic_subscription.Subscription3 module.<MODULE_NAME>.aws_sns_topic_subscription.subscription3
+ * terraform state mv module.<MODULE_NAME>.aws_sns_topic_subscription.Subscription4 module.<MODULE_NAME>.aws_sns_topic_subscription.subscription4
+ * terraform state mv module.<MODULE_NAME>.aws_sns_topic_subscription.Subscription5 module.<MODULE_NAME>.aws_sns_topic_subscription.subscription5
+ * ```
  *
- *### Module variables
+ * ### Module variables
  *
- *The following module variables were updated to better meet current Rackspace style guides:
+ * The following module variables were updated to better meet current Rackspace style guides:
  *
- *- `topic_name` -> `name`
+ * - `topic_name` -> `name`
+ *
+ * ### Limitations
+ * This module does not support `email` or `email-json` as a protocol as  Terraform does not currently support them. See: https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html for more details.
  */
 
 terraform {
@@ -58,39 +61,44 @@ resource "aws_sns_topic" "topic" {
 resource "aws_sns_topic_subscription" "subscription1" {
   count = var.create_subscription_1 ? 1 : 0
 
-  endpoint  = var.endpoint_1
-  protocol  = var.protocol_1
-  topic_arn = aws_sns_topic.topic.arn
+  endpoint               = var.endpoint_1
+  endpoint_auto_confirms = var.endpoint_auto_confirms_1
+  protocol               = var.protocol_1
+  topic_arn              = aws_sns_topic.topic.arn
 }
 
 resource "aws_sns_topic_subscription" "subscription2" {
   count = var.create_subscription_2 ? 1 : 0
 
-  endpoint  = var.endpoint_2
-  protocol  = var.protocol_2
-  topic_arn = aws_sns_topic.topic.arn
+  endpoint               = var.endpoint_2
+  endpoint_auto_confirms = var.endpoint_auto_confirms_2
+  protocol               = var.protocol_2
+  topic_arn              = aws_sns_topic.topic.arn
 }
 
 resource "aws_sns_topic_subscription" "subscription3" {
   count = var.create_subscription_3 ? 1 : 0
 
-  endpoint  = var.endpoint_3
-  protocol  = var.protocol_3
-  topic_arn = aws_sns_topic.topic.arn
+  endpoint               = var.endpoint_3
+  endpoint_auto_confirms = var.endpoint_auto_confirms_3
+  protocol               = var.protocol_3
+  topic_arn              = aws_sns_topic.topic.arn
 }
 
 resource "aws_sns_topic_subscription" "subscription4" {
   count = var.create_subscription_4 ? 1 : 0
 
-  protocol  = var.protocol_4
-  topic_arn = aws_sns_topic.topic.arn
-  endpoint  = var.endpoint_4
+  endpoint               = var.endpoint_4
+  endpoint_auto_confirms = var.endpoint_auto_confirms_4
+  protocol               = var.protocol_4
+  topic_arn              = aws_sns_topic.topic.arn
 }
 
 resource "aws_sns_topic_subscription" "subscription5" {
   count = var.create_subscription_5 ? 1 : 0
 
-  endpoint  = var.endpoint_5
-  protocol  = var.protocol_5
-  topic_arn = aws_sns_topic.topic.arn
+  endpoint               = var.endpoint_5
+  endpoint_auto_confirms = var.endpoint_auto_confirms_5
+  protocol               = var.protocol_5
+  topic_arn              = aws_sns_topic.topic.arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,4 @@
+
 variable "create_subscription_1" {
   description = "Set to true to enable subscription."
   type        = bool
@@ -58,36 +59,63 @@ variable "endpoint_5" {
   default     = ""
 }
 
+variable "endpoint_auto_confirms_1" {
+  description = "Boolean indicating whether endpoint #1 is capable of auto confirming subscription (required for HTTP protocols)."
+  type        = bool
+  default     = false
+}
+
+variable "endpoint_auto_confirms_2" {
+  description = "Boolean indicating whether endpoint #2 is capable of auto confirming subscription (required for HTTP protocols)."
+  type        = bool
+  default     = false
+}
+
+variable "endpoint_auto_confirms_3" {
+  description = "Boolean indicating whether endpoint #3 is capable of auto confirming subscription (required for HTTP protocols)."
+  type        = bool
+  default     = false
+}
+
+variable "endpoint_auto_confirms_4" {
+  description = "Boolean indicating whether endpoint #4 is capable of auto confirming subscription (required for HTTP protocols)."
+  type        = bool
+  default     = false
+}
+
+variable "endpoint_auto_confirms_5" {
+  description = "Boolean indicating whether endpoint #5 is capable of auto confirming subscription (required for HTTP protocols)."
+  type        = bool
+  default     = false
+}
+
+# Terraform does not currently support email or email-json as a protocol. See: https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html
 variable "protocol_1" {
-  # Terraform does not currently support email or email-json as a protocol. See: https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html
   description = "The protocol you want to use in your endpoint #1. Supported protocols include: http, https, sms, sqs, application, lambda."
   type        = string
   default     = ""
 }
 
 variable "protocol_2" {
-  # Terraform does not currently support email or email-json as a protocol. See: https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html
+
   description = "The protocol you want to use in your endpoint #2. Supported protocols include: http, https, sms, sqs, application, lambda."
   type        = string
   default     = ""
 }
 
 variable "protocol_3" {
-  # Terraform does not currently support email or email-json as a protocol. See: https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html
   description = "The protocol you want to use in your endpoint #3. Supported protocols include: http, https, sms, sqs, application, lambda."
   type        = string
   default     = ""
 }
 
 variable "protocol_4" {
-  # Terraform does not currently support email or email-json as a protocol. See: https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html
   description = "The protocol you want to use in your endpoint #4. Supported protocols include: http, https, sms, sqs, application, lambda."
   type        = string
   default     = ""
 }
 
 variable "protocol_5" {
-  # Terraform does not currently support email or email-json as a protocol. See: https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html
   description = "The protocol you want to use in your endpoint #5. Supported protocols include: http, https, sms, sqs, application, lambda."
   type        = string
   default     = ""


### PR DESCRIPTION
##### Corresponding Issue(s):
- https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/256
- https://jira.rax.io/browse/MPCSUPENG-614
##### Summary of change(s):
- expose `endpoint_auto_confirms` property for subscriptions
- update to support latest version of terraform-docs

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
yes
##### Do examples need to be updated based on changes?
no
